### PR TITLE
Add plugin-twitter-rss to registry

### DIFF
--- a/generated-registry.json
+++ b/generated-registry.json
@@ -3477,6 +3477,28 @@
         "v1": true
       }
     },
+    "@elizaos/plugin-twitter-rss": {
+      "git": {
+        "repo": "Dexploarer/elizaos-rss-plugin",
+        "v0": {
+          "version": null,
+          "branch": null
+        },
+        "v1": {
+          "version": null,
+          "branch": "1.x"
+        }
+      },
+      "npm": {
+        "repo": "@elizaos/plugin-twitter-rss",
+        "v0": null,
+        "v1": null
+      },
+      "supports": {
+        "v0": false,
+        "v1": true
+      }
+    },
     "@elizaos-plugins/plugin-venice": {
       "git": {
         "repo": "elizaos-plugins/plugin-venice",

--- a/index.json
+++ b/index.json
@@ -161,6 +161,7 @@
     "@elizaos-plugins/plugin-tts": "github:elizaos-plugins/plugin-tts",
     "@elizaos-plugins/plugin-twilio": "github:boolkeys/plugin-twilio",
     "@elizaos-plugins/plugin-twitter": "github:elizaos-plugins/plugin-twitter",
+    "@elizaos/plugin-twitter-rss": "github:Dexploarer/elizaos-rss-plugin",
     "@elizaos-plugins/plugin-venice": "github:elizaos-plugins/plugin-venice",
     "@elizaos-plugins/plugin-viction": "github:BuildOnViction/plugin-viction",
     "@elizaos-plugins/plugin-video-generation": "github:elizaos-plugins/plugin-video-generation",


### PR DESCRIPTION
## Summary
- register `@elizaos/plugin-twitter-rss`
- regenerate `generated-registry.json`

## Testing
- `npm run generate-registry` *(fails: Connect Timeout Error)*

------
https://chatgpt.com/codex/tasks/task_e_6840ebee9e9483308c4c958a612a8aa6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the "@elizaos/plugin-twitter-rss" plugin, enabling integration with the new Twitter RSS plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->