### PR TITLE
Add rss-feed plugin to registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ All official plugins are hosted at [github.com/elizaos-plugins](https://github.c
 - [@elizaos/plugin-image](https://github.com/elizaos-plugins/plugin-image) - Image processing and analysis
 - [@elizaos/plugin-video](https://github.com/elizaos-plugins/plugin-video) - Video processing capabilities
 - [@elizaos/plugin-local-ai](https://github.com/elizaos-plugins/plugin-local-ai) - Local LLaMA model integration
-
+- [@elizaos-plugins/plugin-rss-feed](https://github.com/jasny/elizaos-rss-feed) - RSS feed ingestion
 Visit the our [Registry Hub](https://eliza.how/packages)
 
 ### Adding Plugins on eliza

--- a/index.json
+++ b/index.json
@@ -135,6 +135,7 @@
     "@elizaos-plugins/plugin-recall": "github:recallnet/plugin-recall",
     "@elizaos-plugins/plugin-redpill": "github:elizaos-plugins/plugin-redpill",
     "@elizaos-plugins/plugin-rss3": "github:rss3-network/elizaos-plugin-rss3",
+    "@elizaos-plugins/plugin-rss-feed": "github:jasny/elizaos-rss-feed",
     "@elizaos-plugins/plugin-safe": "github:5afe/plugin-safe",
     "@elizaos-plugins/plugin-sei": "github:elizaos-plugins/plugin-sei",
     "@elizaos-plugins/plugin-sgx": "github:elizaos-plugins/plugin-sgx",


### PR DESCRIPTION
## Summary
- list `@elizaos-plugins/plugin-rss-feed` in docs
- register the plugin in `index.json`

## Testing
- `npm install`
- `node scripts/generate-registry.js` *(fails: `GITHUB_TOKEN environment variable is required`)*

------
https://chatgpt.com/codex/tasks/task_e_6846517fbe7c833085f2345e9a7d1eca